### PR TITLE
Reopen session when closed

### DIFF
--- a/SwiftFlyer/RealTimeAPI.swift
+++ b/SwiftFlyer/RealTimeAPI.swift
@@ -140,6 +140,10 @@ public final class RealTimeAPI: NSObject {
                 me.delegate?.didReceiveExecution(executions)
             }
         }
+        
+        webSocket.event.close = { [weak self] _,_,_ in
+            self!.webSocket.open() // reopen the socket to the previous url
+        }
     }
     
     public func subscribe(with channels: [String]) {


### PR DESCRIPTION
Sometimes a WebSocket session is closed cause of something bad network condition.