### PR TITLE
Support swift package manager v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ Carthage
 # `pod install` in .travis.yml
 #
 # Pods/
+
+# Swift Package Manager
+.build/
+

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CryptoSwift",
+        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "f2ca9c377d4b44596a131e37eeb908221fb6e6be",
+          "version": "0.8.3"
+        }
+      },
+      {
+        "package": "SSCZLib",
+        "repositoryURL": "https://github.com/c-bata/zlib-spm.git",
+        "state": {
+          "branch": "master",
+          "revision": "0ae9a8ce2260b0a93feaca085e79302ea333978a",
+          "version": null
+        }
+      },
+      {
+        "package": "SSCommonCrypto",
+        "repositoryURL": "https://github.com/daltoniam/common-crypto-spm",
+        "state": {
+          "branch": null,
+          "revision": "2eb3aff0fb57f92f5722fac5d6d20bf64669ca66",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "Starscream",
+        "repositoryURL": "https://github.com/c-bata/Starscream.git",
+        "state": {
+          "branch": "master",
+          "revision": "9c0bf5a65ddf81616cd17e67454c4531c44672e6",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "SwiftFlyer",
+    products: [
+        .library(name: "SwiftFlyer", targets: ["SwiftFlyer"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "0.8.3")),
+        .package(url: "https://github.com/c-bata/Starscream.git", .branch("support-spm4")),
+    ],
+    targets: [
+        .target(
+             name: "SwiftFlyer",
+             dependencies: ["CryptoSwift", "Starscream"],
+             path: "",
+             exclude: ["Example"]
+        )
+    ]
+)
+


### PR DESCRIPTION
First, I need to say this changes are still not perfect because daltoniam/zlib-spm and daltoniam/Starscream didn't support Swift PM v4 yet. So I fork these and add changes to support it. You can check my changes via following pages.

* zlib-spm: https://github.com/daltoniam/zlib-spm/compare/master...c-bata:support-spm4?expand=1
* common-crypto-spm: https://github.com/daltoniam/common-crypto-spm/compare/master...c-bata:support-spm4?expand=1
* Starscream: https://github.com/daltoniam/Starscream/compare/master...c-bata:support-spm4?expand=1

There is a problem when sending a Pull Request to Starscream because C header files are moved inside `include` directory to support Swift PM v4 cause of constraints to support C language targets (See https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#c-language-targets for more details).
So maybe Starscream builds in XCode will be failed cause of changing directory of header files.